### PR TITLE
import fix

### DIFF
--- a/logrus_udp2es.go
+++ b/logrus_udp2es.go
@@ -1,7 +1,7 @@
 package logrus_udp2es
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"net"
 	"fmt"
 	"time"


### PR DESCRIPTION
module declares its path as: github.com/sirupsen/logrus
	        but was required as: github.com/Sirupsen/logrus